### PR TITLE
Support the natural #to_sym => name conversion

### DIFF
--- a/lib/enumerated_type.rb
+++ b/lib/enumerated_type.rb
@@ -68,6 +68,10 @@ module EnumeratedType
     name.to_s
   end
 
+  def to_sym
+    name.to_sym
+  end
+
   def to_json(*)
     '"' + as_json + '"'
   end

--- a/test/enumerated_type_spec.rb
+++ b/test/enumerated_type_spec.rb
@@ -229,6 +229,12 @@ describe EnumeratedType do
     end
   end
 
+  describe "#to_sym" do
+    it "is the name (as a symbol)" do
+      Gender::MALE.to_sym.must_equal :male
+    end
+  end
+
   describe "#to_json" do
     it "is the name (as a string)" do
       Gender::MALE.to_json.must_equal '"male"'


### PR DESCRIPTION
An `EnumeratedType` instance is frequently used in a context where a `Symbol` might otherwise be.

Code expecting a "Symbol-ish or String-ish" often defensively calls `#to_sym` on the object to normalize its recipient, so an `EnumeratedType` should quack that way as well.

The natural `#to_sym` behavior is to return the `name` as `Symbol`.